### PR TITLE
fix: replace execFile with execa for cross-platform command execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ],
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.3",
+        "execa": "^9.6.1",
         "zod": "^3.25.64"
     },
     "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-// Importing execFile from node:child_process to execute shell commands
-import { execFile } from "node:child_process";
+// import execa to replace execFile for cross-platform command execution
+import { execa } from "execa";
 
 const server = new McpServer(
     {
@@ -18,13 +18,9 @@ const server = new McpServer(
 
 const listConnectedSalesforceOrgs = async () => {
     return new Promise((resolve, reject) => {
-        execFile("sf", ["org", "list", "--json"], (error, stdout, stderr) => {
-            if (error) {
-                return reject(error);
-            }
-            if (stderr) {
-                return reject(new Error(stderr));
-            }
+        // use execa instead of execFile, keeping argument array style
+        execa("sf", ["org", "list", "--json"])  
+            .then(({ stdout }) => {
             try {
                 const result = JSON.parse(stdout);
                 resolve(result);
@@ -72,13 +68,9 @@ const executeSoqlQuery = async (
     ];
 
     return new Promise((resolve, reject) => {
-        execFile("sf", args, (error, stdout, stderr) => {
-            if (error) {
-                return reject(error);
-            }
-            if (stderr) {
-                return reject(new Error(stderr));
-            }
+        // use execa instead of execFile, keeping argument array style
+        execa("sf", args)  
+            .then(({ stdout }) => {
             try {
                 const result = JSON.parse(stdout);
                 resolve(result.result.records || []);


### PR DESCRIPTION
Switch from execFile to execa for more reliable cross-platform command execution. Keeps argument-based invocation without spawning a shell, while providing clearer error handling via promise rejection on non-zero exits.